### PR TITLE
Remove erroneous type assert on `Random.seed!`

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -2,7 +2,7 @@ const lowercaseletters = collect('a':'z')
 const uppercaseletters = collect('A':'Z')
 const letters = append!(collect('a':'z'),collect('A':'Z'))
 
-seed(seed::Int=83)::Random.MersenneTwister = Random.seed!(seed)
+seed(seed::Int=83) = Random.seed!(seed)
 random_int(;min::Int=0, max::Int=9999)::String = string(rand(min : max))
 random_digit()::String = string(rand(0:9))
 random_digit_not_null()::String= string(rand(1:9))


### PR DESCRIPTION
If the intent was a stable sequence, then StableRNG.jl must be used and passed explicitly. Otherwise, we can just remove the erroneous function calls.

Refs https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2021-06/03/Faker.1.7.0-DEV-9f32653992.log